### PR TITLE
fix(instance): prevent unknown security_groups value from leaking into state after apply

### DIFF
--- a/internal/models/kafka_instance.go
+++ b/internal/models/kafka_instance.go
@@ -780,7 +780,7 @@ func FlattenKafkaInstanceModel(ctx context.Context, instance *client.InstanceVO,
 			if !sgDiags.HasError() {
 				resource.ComputeSpecs.SecurityGroups = securityGroupsList
 			}
-		} else if previousSpecs != nil && !previousSpecs.SecurityGroups.IsNull() {
+		} else if previousSpecs != nil && !previousSpecs.SecurityGroups.IsNull() && !previousSpecs.SecurityGroups.IsUnknown() {
 			resource.ComputeSpecs.SecurityGroups = previousSpecs.SecurityGroups
 		} else {
 			resource.ComputeSpecs.SecurityGroups = types.ListNull(types.StringType)


### PR DESCRIPTION
## Problem

When creating a `automq_kafka_instance` without specifying `compute_specs.security_groups` (letting the backend auto-generate), Terraform reports:

```
Error: Provider returned invalid result object after apply

After the apply operation, the provider still indicated an unknown value
for automq_kafka_instance.example.compute_specs.security_groups.
```

## Root Cause

`security_groups` is `Optional + Computed + UseStateForUnknown`. On first Create with no user-specified value, the plan value is **Unknown** (not Null).

In `FlattenKafkaInstanceModel`, when the API returns nil/empty `SecurityGroups`, the fallback logic only checked `!IsNull()` before preserving the previous value:

```go
} else if previousSpecs != nil && !previousSpecs.SecurityGroups.IsNull() {
    resource.ComputeSpecs.SecurityGroups = previousSpecs.SecurityGroups // Unknown preserved!
}
```

Since Unknown ≠ Null, `IsNull()` returns false, and the Unknown value leaks into state.

## Fix

Add `!IsUnknown()` check so Unknown values fall through to the Null default:

```go
} else if previousSpecs != nil && !previousSpecs.SecurityGroups.IsNull() && !previousSpecs.SecurityGroups.IsUnknown() {
```

## Note

The same pattern exists in `file_system_param.security_groups` and `data_buckets` — those will be addressed in a follow-up PR.