### PR TITLE
feat: enable table topic in place

### DIFF
--- a/client/model_kafka_instance.go
+++ b/client/model_kafka_instance.go
@@ -135,6 +135,7 @@ type MetricsLabelParam struct {
 }
 
 type TableTopicParam struct {
+	Enabled           *bool   `json:"enabled,omitempty"`
 	IntegrationId     *string `json:"integrationId,omitempty"`
 	Warehouse         string  `json:"warehouse"`
 	CatalogType       string  `json:"catalogType"`

--- a/client/model_kafka_instance_test.go
+++ b/client/model_kafka_instance_test.go
@@ -23,6 +23,7 @@ func TestInstanceCreateParamMarshalMatchesNewContract(t *testing.T) {
 				},
 			},
 			TableTopic: &TableTopicParam{
+				Enabled:     boolPtr(true),
 				Warehouse:   "warehouse",
 				CatalogType: "HIVE",
 			},
@@ -69,10 +70,13 @@ func TestInstanceCreateParamMarshalMatchesNewContract(t *testing.T) {
 	if !ok {
 		t.Fatalf("tableTopic missing or wrong type")
 	}
-	for _, key := range []string{"warehouse", "catalogType"} {
+	for _, key := range []string{"enabled", "warehouse", "catalogType"} {
 		if _, ok := tableTopic[key]; !ok {
 			t.Errorf("expected tableTopic.%s to be present", key)
 		}
+	}
+	if tableTopic["enabled"] != true {
+		t.Fatalf("expected tableTopic.enabled=true, got %v", tableTopic["enabled"])
 	}
 
 	if features["schemaRegistryEnabled"] != true {

--- a/docs/data-sources/kafka_instance.md
+++ b/docs/data-sources/kafka_instance.md
@@ -133,9 +133,9 @@ Read-Only:
 
 - `instance_configs` (Map of String) Additional configuration for the Kafka Instance. The currently supported parameters can be set by referring to the [documentation](https://docs.automq.com/automq-cloud/using-automq-for-kafka/restrictions#instance-level-configuration).
 - `metrics_exporter` (Attributes) Prometheus Remote Write metrics exporter configuration. (see [below for nested schema](#nestedatt--features--metrics_exporter))
-- `schema_registry_enabled` (Boolean) Whether Schema Registry is enabled for this Kafka instance.
+- `schema_registry_enabled` (Boolean) Whether Schema Registry is enabled for this Kafka instance. Table Topic requires this value to be enabled.
 - `security` (Attributes) Security configuration for the Kafka instance. (see [below for nested schema](#nestedatt--features--security))
-- `table_topic` (Attributes) Table topic configuration (warehouse/catalog settings). (see [below for nested schema](#nestedatt--features--table_topic))
+- `table_topic` (Attributes) Table Topic configuration (warehouse/catalog settings). Presence in readback means Table Topic is enabled for the instance. (see [below for nested schema](#nestedatt--features--table_topic))
 - `wal_mode` (String) Write-Ahead Logging mode: EBSWAL (using EBS as write buffer), S3WAL (using object storage as write buffer), or FSWAL (using file system as write buffer). Defaults to EBSWAL.
 
 <a id="nestedatt--features--metrics_exporter"></a>
@@ -173,6 +173,8 @@ Read-Only:
 
 <a id="nestedatt--features--table_topic"></a>
 ### Nested Schema for `features.table_topic`
+
+Readback exposes this block when Table Topic is enabled. The Catalog configuration is immutable after enablement.
 
 Read-Only:
 

--- a/docs/resources/kafka_instance.md
+++ b/docs/resources/kafka_instance.md
@@ -57,6 +57,14 @@ resource "automq_kafka_instance" "example" {
       transit_encryption_modes = ["plaintext"]
     }
     schema_registry_enabled = true
+
+    # Optional. Adding this block enables Table Topic in-place on eligible instances.
+    # Keep schema_registry_enabled explicitly true because Table Topic depends on Schema Registry.
+    # Removing this block from an already-enabled instance is not supported.
+    table_topic = {
+      catalog_type = "glue"
+      warehouse    = "s3://automq-table-topic-warehouse"
+    }
   }
 }
 
@@ -174,8 +182,8 @@ Optional:
 
 - `instance_configs` (Map of String) Additional configuration for the Kafka Instance. The currently supported parameters can be set by referring to the [documentation](https://docs.automq.com/automq-cloud/using-automq-for-kafka/restrictions#instance-level-configuration).
 - `metrics_exporter` (Attributes) Configure Prometheus Remote Write metrics exporter. (see [below for nested schema](#nestedatt--features--metrics_exporter))
-- `schema_registry_enabled` (Boolean) Whether to enable Schema Registry for this Kafka instance.
-- `table_topic` (Attributes) Inline table topic (Iceberg/Hive) configuration replacing legacy integration references. (see [below for nested schema](#nestedatt--features--table_topic))
+- `schema_registry_enabled` (Boolean) Whether to enable Schema Registry for this Kafka instance. Must be explicitly set to `true` when `table_topic` is configured.
+- `table_topic` (Attributes) Inline table topic (Iceberg/Hive) configuration. Presence of this block enables Table Topic and may trigger a rolling restart. Removing this block from an already-enabled instance is not supported. (see [below for nested schema](#nestedatt--features--table_topic))
 
 <a id="nestedatt--features--security"></a>
 ### Nested Schema for `features.security`
@@ -237,6 +245,8 @@ Optional:
 
 <a id="nestedatt--features--table_topic"></a>
 ### Nested Schema for `features.table_topic`
+
+Presence of this block enables Table Topic. It can be added to an eligible existing instance as an in-place update, but Table Topic is open-only: removing the block or trying to close Table Topic after enablement is not supported. Keep `features.schema_registry_enabled = true` in the same configuration.
 
 Required:
 

--- a/examples/resources/automq_kafka_instance/resource.tf
+++ b/examples/resources/automq_kafka_instance/resource.tf
@@ -37,6 +37,13 @@ resource "automq_kafka_instance" "example" {
       transit_encryption_modes = ["plaintext"]
     }
     schema_registry_enabled = true
+
+    # Optional. Adding this block enables Table Topic in-place on eligible instances.
+    # Keep schema_registry_enabled explicitly true because Table Topic depends on Schema Registry.
+    table_topic = {
+      catalog_type = "glue"
+      warehouse    = "s3://automq-table-topic-warehouse"
+    }
   }
 }
 

--- a/internal/models/kafka_instance.go
+++ b/internal/models/kafka_instance.go
@@ -552,6 +552,8 @@ func ExpandKafkaInstanceResource(ctx context.Context, instance KafkaInstanceReso
 				Warehouse:   topicModel.Warehouse.ValueString(),
 				CatalogType: topicModel.CatalogType.ValueString(),
 			}
+			enabled := true
+			topic.Enabled = &enabled
 			if !topicModel.MetastoreURI.IsNull() && !topicModel.MetastoreURI.IsUnknown() {
 				uri := topicModel.MetastoreURI.ValueString()
 				topic.MetastoreUri = &uri

--- a/internal/models/kafka_instance_test.go
+++ b/internal/models/kafka_instance_test.go
@@ -118,6 +118,7 @@ func TestExpandKafkaInstanceResource(t *testing.T) {
 						},
 					},
 					TableTopic: &client.TableTopicParam{
+						Enabled:     boolPtr(true),
 						Warehouse:   "warehouse-1",
 						CatalogType: "HIVE",
 					},

--- a/internal/provider/resource_instance.go
+++ b/internal/provider/resource_instance.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -492,7 +491,7 @@ func (r *KafkaInstanceResource) Schema(ctx context.Context, req resource.SchemaR
 					},
 					"table_topic": schema.SingleNestedAttribute{
 						Optional:            true,
-						MarkdownDescription: "Inline table topic (Iceberg/Hive) configuration replacing legacy integration references.",
+						MarkdownDescription: "Inline table topic (Iceberg/Hive) configuration. Presence of this block enables Table Topic; removing it from an enabled instance is not supported.",
 						Attributes: map[string]schema.Attribute{
 							"warehouse": schema.StringAttribute{
 								Required:            true,
@@ -527,9 +526,6 @@ func (r *KafkaInstanceResource) Schema(ctx context.Context, req resource.SchemaR
 								Optional:            true,
 								MarkdownDescription: "Base64-encoded Kerberos krb5.conf file content. Required when `hive_auth_mode` is `KERBEROS`.",
 							},
-						},
-						PlanModifiers: []planmodifier.Object{
-							objectplanmodifier.RequiresReplace(),
 						},
 					},
 					"schema_registry_enabled": schema.BoolAttribute{
@@ -712,12 +708,26 @@ func validateKafkaInstanceConfiguration(ctx context.Context, plan *models.KafkaI
 		}
 	}
 
-	if plan.Features != nil && plan.Features.TableTopic != nil {
+	var stateTableTopic *models.TableTopicModel
+	if state != nil && state.Features != nil {
+		stateTableTopic = state.Features.TableTopic
+	}
+	var planTableTopic *models.TableTopicModel
+	if plan.Features != nil {
+		planTableTopic = plan.Features.TableTopic
+	}
+	if stateTableTopic != nil && planTableTopic == nil {
+		diagnostics.AddError(
+			"Unsupported Configuration",
+			"Removing features.table_topic from configuration would disable Table Topic, which is not supported. Keep the block in configuration for instances where Table Topic is already enabled.",
+		)
+	}
+	if planTableTopic != nil {
 		enabled := plan.Features.SchemaRegistryEnabled
-		if !enabled.IsNull() && !enabled.IsUnknown() && !enabled.ValueBool() {
+		if enabled.IsNull() || enabled.IsUnknown() || !enabled.ValueBool() {
 			diagnostics.AddError(
 				"Invalid Configuration",
-				"features.schema_registry_enabled cannot be false when features.table_topic is configured.",
+				"features.schema_registry_enabled must be explicitly set to true when features.table_topic is configured.",
 			)
 		}
 	}
@@ -1087,6 +1097,31 @@ func (r *KafkaInstanceResource) Update(ctx context.Context, req resource.UpdateR
 				hasUpdate = true
 				shouldWait = true
 			}
+		}
+	}
+
+	if plan.Features != nil {
+		var stateTableTopic *models.TableTopicModel
+		if state.Features != nil {
+			stateTableTopic = state.Features.TableTopic
+		}
+		if tableTopicChanged(plan.Features.TableTopic, stateTableTopic) {
+			if plan.Features.TableTopic == nil {
+				resp.Diagnostics.AddError(
+					"Unsupported Configuration",
+					"Removing features.table_topic from configuration would disable Table Topic, which is not supported. Keep the block in configuration for instances where Table Topic is already enabled.",
+				)
+				return
+			}
+			tableTopic, err := buildTableTopicParam(plan.Features.TableTopic)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid Configuration", err.Error())
+				return
+			}
+			features := ensureFeatures()
+			features.TableTopic = tableTopic
+			hasUpdate = true
+			shouldWait = true
 		}
 	}
 
@@ -1472,6 +1507,66 @@ func schemaRegistryEnabledChanged(plan, state types.Bool) bool {
 		return false
 	}
 	return !boolAttrEqual(plan, state)
+}
+
+func tableTopicChanged(plan, state *models.TableTopicModel) bool {
+	if plan == nil {
+		return state != nil
+	}
+	if state == nil {
+		return true
+	}
+	return !stringAttrEqual(plan.Warehouse, state.Warehouse) ||
+		!stringAttrEqual(plan.CatalogType, state.CatalogType) ||
+		!stringAttrEqual(plan.MetastoreURI, state.MetastoreURI) ||
+		!stringAttrEqual(plan.HiveAuthMode, state.HiveAuthMode) ||
+		!stringAttrEqual(plan.KerberosPrincipal, state.KerberosPrincipal) ||
+		!stringAttrEqual(plan.UserPrincipal, state.UserPrincipal) ||
+		!stringAttrEqual(plan.KeytabFile, state.KeytabFile) ||
+		!stringAttrEqual(plan.Krb5ConfFile, state.Krb5ConfFile)
+}
+
+func buildTableTopicParam(model *models.TableTopicModel) (*client.TableTopicParam, error) {
+	if model == nil {
+		return nil, nil
+	}
+	if model.Warehouse.IsNull() || model.Warehouse.IsUnknown() {
+		return nil, fmt.Errorf("features.table_topic.warehouse is required when table_topic is set")
+	}
+	if model.CatalogType.IsNull() || model.CatalogType.IsUnknown() {
+		return nil, fmt.Errorf("features.table_topic.catalog_type is required when table_topic is set")
+	}
+	enabled := true
+	topic := &client.TableTopicParam{
+		Enabled:     &enabled,
+		Warehouse:   model.Warehouse.ValueString(),
+		CatalogType: model.CatalogType.ValueString(),
+	}
+	if !model.MetastoreURI.IsNull() && !model.MetastoreURI.IsUnknown() {
+		uri := model.MetastoreURI.ValueString()
+		topic.MetastoreUri = &uri
+	}
+	if !model.HiveAuthMode.IsNull() && !model.HiveAuthMode.IsUnknown() {
+		mode := model.HiveAuthMode.ValueString()
+		topic.HiveAuthMode = &mode
+	}
+	if !model.KerberosPrincipal.IsNull() && !model.KerberosPrincipal.IsUnknown() {
+		principal := model.KerberosPrincipal.ValueString()
+		topic.KerberosPrincipal = &principal
+	}
+	if !model.UserPrincipal.IsNull() && !model.UserPrincipal.IsUnknown() {
+		principal := model.UserPrincipal.ValueString()
+		topic.UserPrincipal = &principal
+	}
+	if !model.KeytabFile.IsNull() && !model.KeytabFile.IsUnknown() {
+		keytab := model.KeytabFile.ValueString()
+		topic.KeytabFile = &keytab
+	}
+	if !model.Krb5ConfFile.IsNull() && !model.Krb5ConfFile.IsUnknown() {
+		conf := model.Krb5ConfFile.ValueString()
+		topic.Krb5ConfFile = &conf
+	}
+	return topic, nil
 }
 
 func stringAttrEqual(plan, state types.String) bool {

--- a/internal/provider/resource_instance_test.go
+++ b/internal/provider/resource_instance_test.go
@@ -1049,6 +1049,7 @@ func renderKafkaInstanceConfig(env accConfig, cfg accInstanceConfig) string {
 	}
 
 	if cfg.TableTopic != nil {
+		b.WriteString("    schema_registry_enabled = true\n")
 		b.WriteString("    table_topic = {\n")
 		fmt.Fprintf(&b, "      warehouse = %q\n", cfg.TableTopic.Warehouse)
 		fmt.Fprintf(&b, "      catalog_type = %q\n", cfg.TableTopic.CatalogType)

--- a/internal/provider/resource_instance_validation_test.go
+++ b/internal/provider/resource_instance_validation_test.go
@@ -164,6 +164,49 @@ func TestSchemaRegistrySchema(t *testing.T) {
 }
 
 func TestValidateKafkaInstanceConfiguration_TableTopicRequiresSchemaRegistryEnabled(t *testing.T) {
+	validBase := &models.KafkaInstanceResourceModel{
+		ComputeSpecs: &models.ComputeSpecsModel{
+			ReservedAku: types.Int64Value(6),
+			DeployType:  types.StringValue("IAAS"),
+			Networks: []models.NetworkModel{{
+				Zone: types.StringValue("cn-test-1"),
+				Subnets: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("subnet-1"),
+				}),
+			}},
+		},
+		Features: &models.FeaturesModel{
+			WalMode: types.StringValue("EBSWAL"),
+			TableTopic: &models.TableTopicModel{
+				Warehouse:   types.StringValue("warehouse"),
+				CatalogType: types.StringValue("HIVE"),
+			},
+			SchemaRegistryEnabled: types.BoolValue(true),
+		},
+	}
+	if diags := validateKafkaInstanceConfiguration(context.Background(), validBase, nil); diags.HasError() {
+		t.Fatalf("unexpected diagnostics for explicit schema_registry_enabled=true: %v", diags)
+	}
+
+	missingSchemaRegistry := *validBase
+	missingFeatures := *validBase.Features
+	missingFeatures.SchemaRegistryEnabled = types.BoolNull()
+	missingSchemaRegistry.Features = &missingFeatures
+	diags := validateKafkaInstanceConfiguration(context.Background(), &missingSchemaRegistry, nil)
+	if !diags.HasError() {
+		t.Fatalf("expected diagnostics when table_topic is configured without schema_registry_enabled=true")
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Detail(), "schema_registry_enabled must be explicitly set to true") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected explicit schema registry dependency error, got: %v", diags)
+	}
+
 	plan := &models.KafkaInstanceResourceModel{
 		ComputeSpecs: &models.ComputeSpecsModel{
 			ReservedAku: types.Int64Value(6),
@@ -185,19 +228,57 @@ func TestValidateKafkaInstanceConfiguration_TableTopicRequiresSchemaRegistryEnab
 		},
 	}
 
-	diags := validateKafkaInstanceConfiguration(context.Background(), plan, nil)
+	diags = validateKafkaInstanceConfiguration(context.Background(), plan, nil)
 	if !diags.HasError() {
 		t.Fatalf("expected diagnostics when table_topic is configured with schema_registry_enabled=false")
 	}
-	found := false
+	found = false
 	for _, d := range diags {
-		if strings.Contains(d.Detail(), "schema_registry_enabled cannot be false") {
+		if strings.Contains(d.Detail(), "schema_registry_enabled must be explicitly set to true") {
 			found = true
 			break
 		}
 	}
 	if !found {
 		t.Fatalf("expected schema registry dependency error, got: %v", diags)
+	}
+}
+
+func TestValidateKafkaInstanceConfiguration_TableTopicRemovalRejected(t *testing.T) {
+	state := &models.KafkaInstanceResourceModel{
+		ComputeSpecs: &models.ComputeSpecsModel{
+			ReservedAku: types.Int64Value(6),
+		},
+		Features: &models.FeaturesModel{
+			TableTopic: &models.TableTopicModel{
+				Warehouse:   types.StringValue("warehouse"),
+				CatalogType: types.StringValue("HIVE"),
+			},
+			SchemaRegistryEnabled: types.BoolValue(true),
+		},
+	}
+	plan := &models.KafkaInstanceResourceModel{
+		ComputeSpecs: &models.ComputeSpecsModel{
+			ReservedAku: types.Int64Value(6),
+		},
+		Features: &models.FeaturesModel{
+			SchemaRegistryEnabled: types.BoolValue(true),
+		},
+	}
+
+	diags := validateKafkaInstanceConfiguration(context.Background(), plan, state)
+	if !diags.HasError() {
+		t.Fatalf("expected diagnostics when table_topic is removed from an enabled instance")
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Detail(), "Removing features.table_topic") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected unsupported table_topic removal error, got: %v", diags)
 	}
 }
 
@@ -261,8 +342,8 @@ func TestImmutableAttributesHaveRequiresReplace(t *testing.T) {
 		t.Fatalf("table_topic attribute has unexpected type %T", featuresAttr.Attributes["table_topic"])
 	}
 	tableTopicAttr := tableTopicAttrRaw
-	if !hasObjectRequiresReplace(tableTopicAttr.PlanModifiers) {
-		t.Fatalf("expected table_topic to require replacement, modifiers: %v", tableTopicAttr.PlanModifiers)
+	if hasObjectRequiresReplace(tableTopicAttr.PlanModifiers) {
+		t.Fatalf("table_topic must support in-place enable and should not require replacement, modifiers: %v", tableTopicAttr.PlanModifiers)
 	}
 	// compute_specs.instance_role
 	instanceRoleAttrRaw, ok := computeAttr.Attributes["instance_role"].(schema.StringAttribute)


### PR DESCRIPTION
## Summary
- keep the existing features.table_topic block as the Table Topic enable/config declaration
- remove unconditional replacement for adding table_topic and send REST tableTopic.enabled=true
- require schema_registry_enabled=true with table_topic and reject removing the block from already-enabled instances
- update provider models, validation tests, docs, and examples

## Verification
- rtk go test ./...
- rtk git diff --check

## Not Run
- live Terraform acceptance apply/plan/readback requires a live AutoMQ control plane environment and credentials.