### PR TITLE
fix: validate connector Terraform contracts

### DIFF
--- a/client/model_connector.go
+++ b/client/model_connector.go
@@ -34,7 +34,6 @@ type ConnectorUpdateParam struct {
 	Name                     *string                        `json:"name,omitempty"`
 	Description              *string                        `json:"description,omitempty"`
 	TaskCount                *int32                         `json:"taskCount,omitempty"`
-	SecurityProtocolConfig   *SecurityProtocolConfig        `json:"securityProtocolConfig,omitempty"`
 	ConnectorConfig          *ConnectorConnectorConfigParam `json:"connectorConfig,omitempty"`
 	ConnectorConfigSensitive *ConnectorConnectorConfigParam `json:"connectorConfigSensitive,omitempty"`
 }

--- a/docs/resources/connector.md
+++ b/docs/resources/connector.md
@@ -68,6 +68,7 @@ variable "aws_secret_access_key" {
 - `connect_cluster_id` (String) ID of the `automq_connect_cluster` that hosts this connector. The target cluster must already have a plugin that provides `connector_class`. Changing this value creates a new connector.
 - `connector_class` (String) Fully-qualified Kafka Connect connector class, such as `io.confluent.connect.s3.S3SinkConnector`. AutoMQ resolves the plugin from the target Connect Cluster by this class. Changing it creates a new connector.
 - `environment_id` (String) AutoMQ environment ID that owns the Connect resources, for example `env-xxxxx`. Changing it creates a new connector.
+- `kafka_cluster` (Attributes) Kafka client authentication used by the connector plugin's producer or consumer clients. Worker-level Kafka authentication is managed by AutoMQ and is not configured here. (see [below for nested schema](#nestedatt--kafka_cluster))
 - `name` (String) Globally unique connector name shown in AutoMQ. It must be 3 to 64 characters.
 - `task_count` (Number) Maximum number of Kafka Connect tasks for this connector. This maps to Connect `tasks.max` and must be at least 1.
 
@@ -77,7 +78,6 @@ variable "aws_secret_access_key" {
 - `connector_config_sensitive` (Map of String, Sensitive) Plugin-specific sensitive connector configuration, such as passwords, tokens, and private keys. Values are marked sensitive in Terraform and retained in state when the API masks them on read.
 - `description` (String) Optional human-readable description for the connector.
 - `initial_offsets` (Attributes List) Initial Kafka Connect offsets to apply when the connector is created. This is create-only; changing it creates a new connector. (see [below for nested schema](#nestedatt--initial_offsets))
-- `kafka_cluster` (Attributes) Kafka client authentication used by the connector plugin's producer or consumer clients. Worker-level Kafka authentication is managed by AutoMQ and is not configured here. (see [below for nested schema](#nestedatt--kafka_cluster))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -88,15 +88,6 @@ variable "aws_secret_access_key" {
 - `plugin_id` (String) Resolved plugin ID. This is computed from `connect_cluster_id` and `connector_class`; it is not an input field.
 - `state` (String) Connector lifecycle state reported by AutoMQ, such as `RUNNING`, `PAUSED`, `CHANGING`, `FAILED`, or `DELETING`.
 - `updated_at` (String) Last update timestamp.
-
-<a id="nestedatt--initial_offsets"></a>
-### Nested Schema for `initial_offsets`
-
-Required:
-
-- `offset` (Map of String) Connector-specific source offset map used by Kafka Connect offsets.
-- `partition` (Map of String) Connector-specific source partition map used by Kafka Connect offsets.
-
 
 <a id="nestedatt--kafka_cluster"></a>
 ### Nested Schema for `kafka_cluster`
@@ -121,6 +112,15 @@ Optional:
 - `truststore_certs` (String) Custom CA certificates in PEM format for SSL trust. If omitted, connector clients use the runtime default trust configuration.
 - `username` (String) SASL username. Required by the backend connector runtime when `protocol` uses SASL.
 
+
+
+<a id="nestedatt--initial_offsets"></a>
+### Nested Schema for `initial_offsets`
+
+Required:
+
+- `offset` (Map of String) Connector-specific source offset map used by Kafka Connect offsets.
+- `partition` (Map of String) Connector-specific source partition map used by Kafka Connect offsets.
 
 
 <a id="nestedatt--timeouts"></a>

--- a/internal/models/connect_cluster.go
+++ b/internal/models/connect_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"gopkg.in/yaml.v3"
 )
 
 type ConnectClusterResourceModel struct {
@@ -145,7 +146,7 @@ func FlattenConnectCluster(vo *client.ConnectClusterVO, state *ConnectClusterRes
 	state.KafkaCluster = flattenClusterKafka(vo, state.KafkaCluster)
 	state.Capacity = flattenClusterCapacity(vo, state.Capacity)
 	state.Compute = flattenClusterCompute(vo, state.Compute)
-	state.WorkerConfig = cFlattenInterfaceMap(vo.WorkerConfig)
+	state.WorkerConfig = cFlattenInterfaceMapRetainEmpty(vo.WorkerConfig, state.WorkerConfig)
 	state.MetricExporter = cFlattenMetrics(vo.MetricExporter, state.MetricExporter)
 	state.Tags = cFlattenStringMap(vo.Tags)
 	state.Version = cToStr(vo.Version)
@@ -224,7 +225,7 @@ func expandClusterCompute(compute *ConnectClusterComputeModel) client.ConnectClu
 			ClusterId:      compute.Kubernetes.ClusterID.ValueString(),
 			Namespace:      compute.Kubernetes.Namespace.ValueString(),
 			ServiceAccount: compute.Kubernetes.ServiceAccount.ValueString(),
-			SchedulingSpec: cOptStr(compute.Kubernetes.SchedulingSpec),
+			SchedulingSpec: cOptNormalizedYAML(compute.Kubernetes.SchedulingSpec),
 		}
 	}
 	return result
@@ -303,7 +304,63 @@ func flattenClusterCompute(vo *client.ConnectClusterVO, prev *ConnectClusterComp
 		prev.Kubernetes.ClusterID = cRetainStr(vo.KubernetesClusterId, prev.Kubernetes.ClusterID)
 		prev.Kubernetes.Namespace = cRetainStr(vo.KubernetesNamespace, prev.Kubernetes.Namespace)
 		prev.Kubernetes.ServiceAccount = cRetainStr(vo.KubernetesServiceAccount, prev.Kubernetes.ServiceAccount)
-		prev.Kubernetes.SchedulingSpec = cRetainStr(vo.SchedulingSpec, prev.Kubernetes.SchedulingSpec)
+		prev.Kubernetes.SchedulingSpec = cRetainNormalizedYAML(vo.SchedulingSpec, prev.Kubernetes.SchedulingSpec)
 	}
 	return prev
+}
+
+func cOptNormalizedYAML(v types.String) *string {
+	if v.IsNull() || v.IsUnknown() {
+		return nil
+	}
+	s := normalizeYAML(v.ValueString())
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func cRetainNormalizedYAML(api *string, existing types.String) types.String {
+	if api != nil {
+		if normalized := normalizeYAML(*api); normalized != "" {
+			return types.StringValue(normalized)
+		}
+		return types.StringNull()
+	}
+	if existing.IsNull() || existing.IsUnknown() {
+		return types.StringNull()
+	}
+	return existing
+}
+
+func normalizeYAML(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	var value interface{}
+	if err := yaml.Unmarshal([]byte(trimmed), &value); err != nil {
+		return trimmed
+	}
+	if isEmptyYAMLValue(value) {
+		return ""
+	}
+	out, err := yaml.Marshal(value)
+	if err != nil {
+		return trimmed
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func isEmptyYAMLValue(value interface{}) bool {
+	switch typed := value.(type) {
+	case nil:
+		return true
+	case map[string]interface{}:
+		return len(typed) == 0
+	case []interface{}:
+		return len(typed) == 0
+	default:
+		return false
+	}
 }

--- a/internal/models/connect_cluster_test.go
+++ b/internal/models/connect_cluster_test.go
@@ -99,3 +99,84 @@ func TestFlattenConnectCluster(t *testing.T) {
 	assert.Equal(t, int64(2), state.Capacity.Provisioned.WorkerCount.ValueInt64())
 	assert.Equal(t, "3.9.0", state.KafkaConnectVersion.ValueString())
 }
+
+func TestFlattenConnectCluster_RetainsEmptyWorkerConfig(t *testing.T) {
+	ctx := context.Background()
+	emptyWorkerConfig, diags := types.MapValueFrom(ctx, types.StringType, map[string]string{})
+	assert.False(t, diags.HasError())
+	state := &ConnectClusterResourceModel{WorkerConfig: emptyWorkerConfig}
+
+	diags = FlattenConnectCluster(&client.ConnectClusterVO{Id: connStrPtr("connect-cluster-1")}, state)
+	assert.False(t, diags.HasError())
+	assert.False(t, state.WorkerConfig.IsNull())
+	assert.Empty(t, state.WorkerConfig.Elements())
+}
+
+func TestConnectClusterSchedulingSpec_NormalizesEquivalentYAML(t *testing.T) {
+	input := "nodeSelector:\n  dedicated: automq-connect\ntolerations:\n- key: dedicated\n  operator: Equal\n  value: automq-connect\n  effect: NoSchedule\n"
+	api := "nodeSelector: {dedicated: automq-connect}\ntolerations:\n  - {key: dedicated, operator: Equal, value: automq-connect, effect: NoSchedule}\n"
+	plan := ConnectClusterResourceModel{
+		Name: types.StringValue("cluster-a"),
+		Plugins: []ConnectClusterPluginModel{
+			{Name: types.StringValue("s3-sink"), Version: types.StringValue("11.1.0")},
+		},
+		KafkaCluster: &ConnectClusterKafkaModel{KafkaInstanceID: types.StringValue("kf-1")},
+		Capacity: &ConnectClusterCapacityModel{
+			Type: types.StringValue("provisioned"),
+			Provisioned: &ConnectClusterProvisionedCapacityModel{
+				WorkerResourceSpec: types.StringValue("TIER1"),
+				WorkerCount:        types.Int64Value(1),
+			},
+		},
+		Compute: &ConnectClusterComputeModel{
+			Type: types.StringValue("k8s"),
+			Kubernetes: &ConnectClusterKubernetesModel{
+				ClusterID:      types.StringValue("eks-1"),
+				Namespace:      types.StringValue("connect"),
+				ServiceAccount: types.StringValue("connect-sa"),
+				SchedulingSpec: types.StringValue(input),
+			},
+		},
+	}
+
+	req, diags := ExpandConnectClusterCreate(plan)
+	assert.False(t, diags.HasError())
+	assert.NotNil(t, req.Compute.Kubernetes.SchedulingSpec)
+
+	state := &ConnectClusterResourceModel{Compute: plan.Compute}
+	diags = FlattenConnectCluster(&client.ConnectClusterVO{Id: connStrPtr("connect-cluster-1"), SchedulingSpec: &api}, state)
+	assert.False(t, diags.HasError())
+	assert.Equal(t, *req.Compute.Kubernetes.SchedulingSpec, state.Compute.Kubernetes.SchedulingSpec.ValueString())
+}
+
+func TestConnectClusterSchedulingSpec_EmptyYamlIsOmitted(t *testing.T) {
+	for _, input := range []string{"", "   \n", "{}\n", "[]"} {
+		plan := ConnectClusterResourceModel{
+			Name: types.StringValue("cluster-a"),
+			Plugins: []ConnectClusterPluginModel{
+				{Name: types.StringValue("s3-sink"), Version: types.StringValue("11.1.0")},
+			},
+			KafkaCluster: &ConnectClusterKafkaModel{KafkaInstanceID: types.StringValue("kf-1")},
+			Capacity: &ConnectClusterCapacityModel{
+				Type: types.StringValue("provisioned"),
+				Provisioned: &ConnectClusterProvisionedCapacityModel{
+					WorkerResourceSpec: types.StringValue("TIER1"),
+					WorkerCount:        types.Int64Value(1),
+				},
+			},
+			Compute: &ConnectClusterComputeModel{
+				Type: types.StringValue("k8s"),
+				Kubernetes: &ConnectClusterKubernetesModel{
+					ClusterID:      types.StringValue("eks-1"),
+					Namespace:      types.StringValue("connect"),
+					ServiceAccount: types.StringValue("connect-sa"),
+					SchedulingSpec: types.StringValue(input),
+				},
+			},
+		}
+
+		req, diags := ExpandConnectClusterCreate(plan)
+		assert.False(t, diags.HasError())
+		assert.Nil(t, req.Compute.Kubernetes.SchedulingSpec)
+	}
+}

--- a/internal/models/connector.go
+++ b/internal/models/connector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -79,10 +80,9 @@ func ExpandConnectorCreate(plan ConnectorResourceModel) (*client.ConnectorCreate
 	if s := cOptStr(plan.Description); s != nil {
 		request.Description = s
 	}
-	if plan.KafkaCluster != nil && plan.KafkaCluster.Security != nil {
-		request.KafkaCluster = &client.ConnectorKafkaClusterParam{
-			SecurityProtocolConfig: cExpandSecurityProtocol(plan.KafkaCluster.Security),
-		}
+	securityConfig := requiredSecurityProtocolConfig(plan.KafkaCluster, &diags)
+	if securityConfig != nil {
+		request.KafkaCluster = &client.ConnectorKafkaClusterParam{SecurityProtocolConfig: securityConfig}
 	}
 	if m := cExpandStringMap(plan.ConnectorConfig); m != nil {
 		request.ConnectorConfig = &client.ConnectorConnectorConfigParam{Properties: m}
@@ -108,9 +108,6 @@ func ExpandConnectorUpdate(plan ConnectorResourceModel) (*client.ConnectorUpdate
 	if !plan.TaskCount.IsNull() && !plan.TaskCount.IsUnknown() {
 		tc := int32(plan.TaskCount.ValueInt64())
 		request.TaskCount = &tc
-	}
-	if plan.KafkaCluster != nil && plan.KafkaCluster.Security != nil {
-		request.SecurityProtocolConfig = cExpandSecurityProtocol(plan.KafkaCluster.Security)
 	}
 	if m := cExpandStringMap(plan.ConnectorConfig); m != nil {
 		request.ConnectorConfig = &client.ConnectorConnectorConfigParam{Properties: m}
@@ -179,6 +176,59 @@ func cExpandSecurityProtocol(m *SecurityProtocolConfigModel) *client.SecurityPro
 	}
 }
 
+func requiredSecurityProtocolConfig(kafka *ConnectorKafkaClusterModel, diags *diag.Diagnostics) *client.SecurityProtocolConfig {
+	if kafka == nil || kafka.Security == nil {
+		diags.AddError("Missing connector Kafka security protocol", "`kafka_cluster.security_protocol` is required for connector resources.")
+		return nil
+	}
+	cfg := cExpandSecurityProtocol(kafka.Security)
+	protocol := ""
+	if cfg != nil && cfg.SecurityProtocol != nil {
+		protocol = *cfg.SecurityProtocol
+	}
+	if protocol == "" {
+		diags.AddAttributeError(
+			path.Root("kafka_cluster").AtName("security_protocol").AtName("protocol"),
+			"Missing connector Kafka security protocol",
+			"`protocol` is required in connector `kafka_cluster.security_protocol`.",
+		)
+		return nil
+	}
+	switch protocol {
+	case "SASL_PLAINTEXT", "SASL_SSL":
+		if cfg.Username == nil || *cfg.Username == "" {
+			diags.AddAttributeError(
+				path.Root("kafka_cluster").AtName("security_protocol").AtName("username"),
+				"Missing SASL username",
+				"`username` is required when connector `protocol` is SASL_PLAINTEXT or SASL_SSL.",
+			)
+		}
+		if cfg.Password == nil || *cfg.Password == "" {
+			diags.AddAttributeError(
+				path.Root("kafka_cluster").AtName("security_protocol").AtName("password"),
+				"Missing SASL password",
+				"`password` is required when connector `protocol` is SASL_PLAINTEXT or SASL_SSL.",
+			)
+		}
+	case "SSL":
+		if cfg.ClientCert == nil || *cfg.ClientCert == "" {
+			diags.AddAttributeError(
+				path.Root("kafka_cluster").AtName("security_protocol").AtName("client_cert"),
+				"Missing client certificate",
+				"`client_cert` is required when connector `protocol` is SSL.",
+			)
+		}
+		if cfg.PrivateKey == nil || *cfg.PrivateKey == "" {
+			diags.AddAttributeError(
+				path.Root("kafka_cluster").AtName("security_protocol").AtName("private_key"),
+				"Missing private key",
+				"`private_key` is required when connector `protocol` is SSL.",
+			)
+		}
+	}
+	return cfg
+}
+
 func cExpandMetrics(m *ConnectorMetricsExporterModel) *client.ConnectMetricsConfigParam {
 	if m == nil || m.RemoteWrite == nil {
 		return nil
@@ -231,8 +281,8 @@ func cFlattenSecurityProtocol(cfg *client.SecurityProtocolConfig, prev *Security
 	m.Protocol = cRetainStr(firstString(cfg.Protocol, cfg.SecurityProtocol), m.Protocol)
 	m.Username = cRetainStr(cfg.Username, m.Username)
 	m.Password = cRetainStr(cfg.Password, m.Password)
-	m.SaslMechanism = cRetainStr(cfg.SaslMechanism, m.SaslMechanism)
-	m.TruststoreCerts = cRetainStr(cfg.TruststoreCerts, m.TruststoreCerts)
+	m.SaslMechanism = cRetainOptionalInputStr(cfg.SaslMechanism, m.SaslMechanism)
+	m.TruststoreCerts = cRetainOptionalInputStr(cfg.TruststoreCerts, m.TruststoreCerts)
 	m.ClientCert = cRetainStr(cfg.ClientCert, m.ClientCert)
 	m.PrivateKey = cRetainStr(cfg.PrivateKey, m.PrivateKey)
 	return m
@@ -301,6 +351,16 @@ func cFlattenInterfaceMap(src map[string]interface{}) types.Map {
 	return types.MapValueMust(types.StringType, vals)
 }
 
+func cFlattenInterfaceMapRetainEmpty(src map[string]interface{}, existing types.Map) types.Map {
+	if len(src) > 0 {
+		return cFlattenInterfaceMap(src)
+	}
+	if !existing.IsNull() && !existing.IsUnknown() && len(existing.Elements()) == 0 {
+		return existing
+	}
+	return types.MapNull(types.StringType)
+}
+
 func cFlattenStringMap(src map[string]string) types.Map {
 	if len(src) == 0 {
 		return types.MapNull(types.StringType)
@@ -328,6 +388,16 @@ func cRetainStr(api *string, existing types.String) types.String {
 	}
 	if existing.IsNull() || existing.IsUnknown() {
 		return types.StringNull()
+	}
+	return existing
+}
+
+func cRetainOptionalInputStr(api *string, existing types.String) types.String {
+	if existing.IsNull() || existing.IsUnknown() {
+		return types.StringNull()
+	}
+	if api != nil {
+		return types.StringValue(*api)
 	}
 	return existing
 }

--- a/internal/models/connector_test.go
+++ b/internal/models/connector_test.go
@@ -60,6 +60,98 @@ func TestExpandConnectorCreate(t *testing.T) {
 	assert.Equal(t, "123", req.InitialOffsets[0].Offset["pos"])
 }
 
+func TestExpandConnectorCreate_RequiresKafkaClusterSecurityProtocol(t *testing.T) {
+	plan := ConnectorResourceModel{
+		ConnectClusterID: types.StringValue("connect-cluster-1"),
+		Name:             types.StringValue("test-connector"),
+		ConnectorClass:   types.StringValue("io.example.SourceConnector"),
+		TaskCount:        types.Int64Value(1),
+	}
+
+	_, diags := ExpandConnectorCreate(plan)
+	assert.True(t, diags.HasError())
+}
+
+func TestExpandConnectorCreate_AllowsPlaintextWithoutCredentials(t *testing.T) {
+	plan := ConnectorResourceModel{
+		ConnectClusterID: types.StringValue("connect-cluster-1"),
+		Name:             types.StringValue("test-connector"),
+		ConnectorClass:   types.StringValue("io.example.SourceConnector"),
+		TaskCount:        types.Int64Value(1),
+		KafkaCluster: &ConnectorKafkaClusterModel{
+			Security: &SecurityProtocolConfigModel{
+				Protocol: types.StringValue("PLAINTEXT"),
+			},
+		},
+	}
+
+	req, diags := ExpandConnectorCreate(plan)
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	assert.Equal(t, "PLAINTEXT", *req.KafkaCluster.SecurityProtocolConfig.Protocol)
+	assert.Nil(t, req.KafkaCluster.SecurityProtocolConfig.Username)
+	assert.Nil(t, req.KafkaCluster.SecurityProtocolConfig.Password)
+	assert.Nil(t, req.KafkaCluster.SecurityProtocolConfig.ClientCert)
+	assert.Nil(t, req.KafkaCluster.SecurityProtocolConfig.PrivateKey)
+}
+
+func TestExpandConnectorCreate_IgnoresUnknownComputedSecurityFields(t *testing.T) {
+	plan := ConnectorResourceModel{
+		ConnectClusterID: types.StringValue("connect-cluster-1"),
+		Name:             types.StringValue("test-connector"),
+		ConnectorClass:   types.StringValue("io.example.SourceConnector"),
+		TaskCount:        types.Int64Value(1),
+		KafkaCluster: &ConnectorKafkaClusterModel{
+			Security: &SecurityProtocolConfigModel{
+				Protocol:        types.StringValue("PLAINTEXT"),
+				SaslMechanism:   types.StringUnknown(),
+				TruststoreCerts: types.StringUnknown(),
+			},
+		},
+	}
+
+	req, diags := ExpandConnectorCreate(plan)
+	assert.False(t, diags.HasError(), "unexpected diagnostics: %v", diags)
+	assert.Equal(t, "PLAINTEXT", *req.KafkaCluster.SecurityProtocolConfig.Protocol)
+	assert.Nil(t, req.KafkaCluster.SecurityProtocolConfig.SaslMechanism)
+	assert.Nil(t, req.KafkaCluster.SecurityProtocolConfig.TruststoreCerts)
+}
+
+func TestExpandConnectorCreate_ValidatesSaslCredentials(t *testing.T) {
+	plan := ConnectorResourceModel{
+		ConnectClusterID: types.StringValue("connect-cluster-1"),
+		Name:             types.StringValue("test-connector"),
+		ConnectorClass:   types.StringValue("io.example.SourceConnector"),
+		TaskCount:        types.Int64Value(1),
+		KafkaCluster: &ConnectorKafkaClusterModel{
+			Security: &SecurityProtocolConfigModel{
+				Protocol: types.StringValue("SASL_PLAINTEXT"),
+			},
+		},
+	}
+
+	_, diags := ExpandConnectorCreate(plan)
+	assert.True(t, diags.HasError())
+	assert.Len(t, diags, 2)
+}
+
+func TestExpandConnectorCreate_ValidatesSslCredentials(t *testing.T) {
+	plan := ConnectorResourceModel{
+		ConnectClusterID: types.StringValue("connect-cluster-1"),
+		Name:             types.StringValue("test-connector"),
+		ConnectorClass:   types.StringValue("io.example.SourceConnector"),
+		TaskCount:        types.Int64Value(1),
+		KafkaCluster: &ConnectorKafkaClusterModel{
+			Security: &SecurityProtocolConfigModel{
+				Protocol: types.StringValue("SSL"),
+			},
+		},
+	}
+
+	_, diags := ExpandConnectorCreate(plan)
+	assert.True(t, diags.HasError())
+	assert.Len(t, diags, 2)
+}
+
 func TestExpandConnectorUpdate(t *testing.T) {
 	config, diags := types.MapValueFrom(context.Background(), types.StringType, map[string]string{"topics": "orders-updated"})
 	assert.False(t, diags.HasError())
@@ -69,9 +161,6 @@ func TestExpandConnectorUpdate(t *testing.T) {
 		Description:     types.StringValue("new desc"),
 		TaskCount:       types.Int64Value(5),
 		ConnectorConfig: config,
-		KafkaCluster: &ConnectorKafkaClusterModel{
-			Security: &SecurityProtocolConfigModel{Protocol: types.StringValue("PLAINTEXT")},
-		},
 	}
 
 	req, diags := ExpandConnectorUpdate(plan)
@@ -79,7 +168,6 @@ func TestExpandConnectorUpdate(t *testing.T) {
 	assert.Equal(t, "updated", *req.Name)
 	assert.Equal(t, "new desc", *req.Description)
 	assert.Equal(t, int32(5), *req.TaskCount)
-	assert.Equal(t, "PLAINTEXT", *req.SecurityProtocolConfig.Protocol)
 	assert.Equal(t, "orders-updated", req.ConnectorConfig.Properties["topics"])
 }
 
@@ -122,6 +210,59 @@ func TestFlattenConnector(t *testing.T) {
 	configVal, ok := state.ConnectorConfig.Elements()["topics"].(types.String)
 	assert.True(t, ok)
 	assert.Equal(t, "orders", configVal.ValueString())
+}
+
+func TestFlattenConnector_DoesNotPersistUnconfiguredSecurityDefaults(t *testing.T) {
+	vo := &client.ConnectorVO{
+		Id: connStrPtr("conn-1"),
+		SecurityProtocolConfig: &client.SecurityProtocolConfig{
+			Protocol:        connStrPtr("SASL_PLAINTEXT"),
+			SaslMechanism:   connStrPtr("SCRAM-SHA-512"),
+			TruststoreCerts: connStrPtr("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"),
+		},
+	}
+	state := &ConnectorResourceModel{
+		KafkaCluster: &ConnectorKafkaClusterModel{
+			Security: &SecurityProtocolConfigModel{
+				Protocol:        types.StringValue("SASL_PLAINTEXT"),
+				SaslMechanism:   types.StringNull(),
+				TruststoreCerts: types.StringNull(),
+			},
+		},
+	}
+
+	diags := FlattenConnector(vo, state)
+
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "SASL_PLAINTEXT", state.KafkaCluster.Security.Protocol.ValueString())
+	assert.True(t, state.KafkaCluster.Security.SaslMechanism.IsNull())
+	assert.True(t, state.KafkaCluster.Security.TruststoreCerts.IsNull())
+}
+
+func TestFlattenConnector_RetainsConfiguredSecurityFields(t *testing.T) {
+	vo := &client.ConnectorVO{
+		Id: connStrPtr("conn-1"),
+		SecurityProtocolConfig: &client.SecurityProtocolConfig{
+			Protocol:        connStrPtr("SASL_SSL"),
+			SaslMechanism:   connStrPtr("PLAIN"),
+			TruststoreCerts: connStrPtr("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"),
+		},
+	}
+	state := &ConnectorResourceModel{
+		KafkaCluster: &ConnectorKafkaClusterModel{
+			Security: &SecurityProtocolConfigModel{
+				Protocol:        types.StringValue("SASL_SSL"),
+				SaslMechanism:   types.StringValue("PLAIN"),
+				TruststoreCerts: types.StringValue("-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----"),
+			},
+		},
+	}
+
+	diags := FlattenConnector(vo, state)
+
+	assert.False(t, diags.HasError())
+	assert.Equal(t, "PLAIN", state.KafkaCluster.Security.SaslMechanism.ValueString())
+	assert.Contains(t, state.KafkaCluster.Security.TruststoreCerts.ValueString(), "BEGIN CERTIFICATE")
 }
 
 func TestFlattenConnector_RetainsSensitiveConfig(t *testing.T) {

--- a/internal/provider/resource_connect_cluster.go
+++ b/internal/provider/resource_connect_cluster.go
@@ -243,6 +243,12 @@ func (r *ConnectClusterResource) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError("Create Connect Cluster Error", "API returned empty connect cluster id")
 		return
 	}
+	plan.ID = types.StringValue(clusterID)
+	plan.State = types.StringValue(derefStringWithDefault(created.State, client.ConnectClusterStateCreating))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	if err := waitForConnectClusterReady(ctx, r.api, clusterID, r.CreateTimeout(ctx, plan.Timeouts)); err != nil {
 		resp.Diagnostics.AddError("Connect Cluster Provisioning Error", err.Error())
 		return

--- a/internal/provider/resource_connector.go
+++ b/internal/provider/resource_connector.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -146,8 +147,11 @@ func (r *ConnectorResource) Schema(ctx context.Context, _ resource.SchemaRequest
 				PlanModifiers: []planmodifier.Map{mapplanmodifier.UseStateForUnknown()},
 			},
 			"kafka_cluster": schema.SingleNestedAttribute{
-				Optional:    true,
+				Required:    true,
 				Description: "Kafka client authentication used by the connector plugin's producer or consumer clients. Worker-level Kafka authentication is managed by AutoMQ and is not configured here.",
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"security_protocol": schema.SingleNestedAttribute{
 						Required:    true,
@@ -161,16 +165,12 @@ func (r *ConnectorResource) Schema(ctx context.Context, _ resource.SchemaRequest
 							"username": schema.StringAttribute{Optional: true, Description: "SASL username. Required by the backend connector runtime when `protocol` uses SASL."},
 							"password": schema.StringAttribute{Optional: true, Sensitive: true, Description: "SASL password. Required by the backend connector runtime when `protocol` uses SASL."},
 							"sasl_mechanism": schema.StringAttribute{
-								Optional:      true,
-								Computed:      true,
-								Description:   "SASL mechanism, such as `SCRAM-SHA-512`. If omitted for a SASL protocol, AutoMQ defaults to `SCRAM-SHA-512`.",
-								PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+								Optional:    true,
+								Description: "SASL mechanism, such as `SCRAM-SHA-512`. If omitted for a SASL protocol, AutoMQ defaults to `SCRAM-SHA-512`.",
 							},
 							"truststore_certs": schema.StringAttribute{
-								Optional:      true,
-								Computed:      true,
-								Description:   "Custom CA certificates in PEM format for SSL trust. If omitted, connector clients use the runtime default trust configuration.",
-								PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+								Optional:    true,
+								Description: "Custom CA certificates in PEM format for SSL trust. If omitted, connector clients use the runtime default trust configuration.",
 							},
 							"client_cert": schema.StringAttribute{Optional: true, Description: "Client certificate chain in PEM format for mTLS."},
 							"private_key": schema.StringAttribute{Optional: true, Sensitive: true, Description: "Client private key in PEM format for mTLS."},
@@ -239,6 +239,12 @@ func (r *ConnectorResource) Create(ctx context.Context, req resource.CreateReque
 	connectorID := derefString(created.Id)
 	if connectorID == "" {
 		resp.Diagnostics.AddError("Create Connector Error", "API returned empty connector id")
+		return
+	}
+	plan.ID = types.StringValue(connectorID)
+	plan.State = types.StringValue(derefStringWithDefault(created.State, client.ConnectorStateCreating))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	if err := waitForConnectorReady(ctx, r.api, connectorID, r.CreateTimeout(ctx, plan.Timeouts)); err != nil {
@@ -407,4 +413,11 @@ func derefString(v *string) string {
 		return ""
 	}
 	return *v
+}
+
+func derefStringWithDefault(value *string, fallback string) string {
+	if value == nil || *value == "" {
+		return fallback
+	}
+	return *value
 }

--- a/internal/provider/resource_connector_plugin.go
+++ b/internal/provider/resource_connector_plugin.go
@@ -192,6 +192,12 @@ func (r *ConnectorPluginResource) Create(ctx context.Context, req resource.Creat
 		resp.Diagnostics.AddError("Create Connector Plugin Error", "API returned empty plugin id")
 		return
 	}
+	plan.ID = types.StringValue(pluginID)
+	plan.Status = types.StringValue(derefStringWithDefault(created.Status, client.PluginStatePending))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	if err := waitForPluginActive(ctx, r.api, pluginID, r.CreateTimeout(ctx, plan.Timeouts)); err != nil {
 		resp.Diagnostics.AddError("Connector Plugin Provisioning Error", err.Error())


### PR DESCRIPTION
## Summary
- make connector `kafka_cluster.security_protocol` required in Terraform and fail plan expansion when SASL/SSL credentials are incomplete
- keep `PLAINTEXT` connector protocol usable without SASL/SSL-only fields
- avoid `Optional+Computed` default drift for connector `sasl_mechanism` and `truststore_certs`; backend defaults are not persisted unless explicitly configured
- mark connector Kafka security changes as replacement to avoid state/runtime drift
- persist partial state immediately after asynchronous Connect resource create APIs return an ID, so create timeouts still leave `CREATING`/`PENDING` resources manageable in Terraform state
- retain explicit empty `worker_config = {}` and normalize equivalent Kubernetes `scheduling_spec` YAML to avoid inconsistent plans
- omit empty Kubernetes `compute.kubernetes.scheduling_spec` values such as `{}`/`[]`/blank instead of sending invalid scheduling constraints to the API
- regenerate connector resource docs

## Related issues
- AutoMQ/automqbox#5998
- AutoMQ/automqbox#5999
- AutoMQ/automqbox#6003 is already fixed on provider main by the connect plugin route change; this PR keeps the Terraform contract fixes needed for the same test flow

## Tests
- `go test ./internal/models ./internal/provider ./client`
