### PR TITLE
fix(client): encode GET query parameters

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"terraform-provider-automq/client/signer"
 	"time"
@@ -147,11 +148,11 @@ func (c *Client) Patch(ctx context.Context, path string, body interface{}) ([]by
 }
 
 func buildQueryParams(queryParams map[string]string) string {
-	query := ""
+	query := url.Values{}
 	for key, value := range queryParams {
-		query += key + "=" + value + "&"
+		query.Set(key, value)
 	}
-	return query
+	return query.Encode()
 }
 
 func (c *Client) doRequest(ctx context.Context, method, path string, body io.Reader) ([]byte, error) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBuildQueryParamsEscapesSpecialCharacters(t *testing.T) {
+	query := buildQueryParams(map[string]string{
+		"exactUser":         "automq-connect",
+		"fuzzyResourceName": "*",
+		"path":              "foo/bar baz",
+	})
+
+	values, err := url.ParseQuery(query)
+	if err != nil {
+		t.Fatalf("ParseQuery(%q) failed: %v", query, err)
+	}
+
+	if got := values.Get("fuzzyResourceName"); got != "*" {
+		t.Fatalf("fuzzyResourceName = %q, want *", got)
+	}
+	if got := values.Get("path"); got != "foo/bar baz" {
+		t.Fatalf("path = %q, want foo/bar baz", got)
+	}
+	if strings.Contains(query, "fuzzyResourceName=*") {
+		t.Fatalf("wildcard query value was not URL encoded: %q", query)
+	}
+	if !strings.Contains(query, "fuzzyResourceName=%2A") {
+		t.Fatalf("wildcard query value was not encoded as %%2A: %q", query)
+	}
+}


### PR DESCRIPTION
## Summary
- encode GET query parameters with url.Values instead of string concatenation
- cover wildcard query values such as Kafka ACL fuzzyResourceName=*

## Context
GCP Connect testing created Kafka ACLs with resource_name="*" successfully, but subsequent Terraform refresh/read failed with Iam.IncorrectApiSignature for automq_kafka_acl resources. The client was building raw query strings manually, leaving special characters like * unescaped before request signing.

## Tests
- go test ./...