### PR TITLE
ci: update lock threads action

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # NOTE: When TSCCR updates the GitHub action version, update the template workflow file to avoid drift:
       # https://github.com/hashicorp/terraform-devex-repos/blob/main/modules/repo/workflows/lock.tftpl
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@89ae32b08ed1a541efecbab17912962a5e38981c # v6.0.2
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: '30'


### PR DESCRIPTION
## Summary

- update `dessant/lock-threads` from v5.0.1 to v6.0.2
- support the new ~520-character stateless `GITHUB_TOKEN` format
- move the action runtime from Node.js 20 to Node.js 24

## Validation

- `git diff --check`
- verified the v6.0.2 schema accepts a 520-character token

## Note

This workflow is managed by `hashicorp/terraform-devex-repos`; its `lock.tftpl` source of truth should receive the same pin update to prevent automation drift.